### PR TITLE
corrected the name of the command for clone-repos

### DIFF
--- a/_docs/10-classroom-clone-repos.md
+++ b/_docs/10-classroom-clone-repos.md
@@ -11,7 +11,7 @@ Clone repos to a local directory on your machine.
 Usage:
 
 ```sh
- $ bin/task/update-access-permissions ASSIGNMENT-CONFIG LOCAL-DIR
+ $ bin/task/clone-repos ASSIGNMENT-CONFIG LOCAL-DIR
 ```
 
 ### Minimal configuration


### PR DESCRIPTION
Fixed from `make-access-permissions` which was presumably a copy and paste
